### PR TITLE
Feat/remote zarr

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - modo-network
     environment:
       - S3_LOCAL_URL=${S3_LOCAL_URL:-http://minio:9000}
+      - S3_PUBLIC_URL=${S3_PUBLIC_URL:-http://localhost/s3}
       - HTSGET_LOCAL_URL=${HTSGET_LOCAL_URL:-http://htsget:8080}
       - S3_BUCKET=${S3_BUCKET:-modo-demo}
     command: uvicorn --host 0.0.0.0 --port 8000 --reload server:app

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -18,6 +18,7 @@ import zarr
 
 
 S3_LOCAL_URL = os.environ["S3_LOCAL_URL"]
+S3_PUBLIC_URL = os.environ["S3_PUBLIC_URL"]
 BUCKET = os.environ["S3_BUCKET"]
 HTSGET_LOCAL_URL = os.environ["HTSGET_LOCAL_URL"]
 
@@ -63,4 +64,4 @@ def get_s3_path(query: str, exact_match: bool = False):
             for modo in modos
             if re.search("/" + query + r"$", modo) is not None
         ]
-    return [f"{S3_LOCAL_URL}/{modo}" for modo in res]
+    return [f"{S3_PUBLIC_URL}/{modo}" for modo in res]

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -11,11 +11,8 @@ import os
 
 from fastapi import FastAPI
 from modo.api import MODO
-<<<<<<< HEAD
-=======
 import rdflib
 import re
->>>>>>> d2468b5 (feat: Add get?query to modo server)
 import s3fs
 import zarr
 
@@ -46,8 +43,9 @@ def gather_metadata():
         archive = zarr.open(
             store=store,
         )
-        # TODO: Fix id_ to id once restructure/herarchy is accepted!
-        meta.update(MODO(path=f"{S3_LOCAL_URL}/{modo}", archive=archive).metadata)
+        meta.update(
+            MODO(path=f"{S3_LOCAL_URL}/{modo}", archive=archive).metadata
+        )
 
     return meta
 
@@ -65,4 +63,4 @@ def get_s3_path(query: str, exact_match: bool = False):
             for modo in modos
             if re.search("/" + query + r"$", modo) is not None
         ]
-    return [f"{S3_URL}/{modo}" for modo in res]
+    return [f"{S3_LOCAL_URL}/{modo}" for modo in res]

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -48,7 +48,7 @@ def get_s3_path(query: str, exact_match: bool = False):
     modos = minio.ls(BUCKET)
     if exact_match:
         res = [
-            modo for modo in modos if query in modo.replace(BUCKET + "/", "")
+            modo for modo in modos if query in modo.removeprefix(BUCKET)
         ]
     else:
         res = [

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -41,6 +41,7 @@ def gather_metadata():
         archive = zarr.open(
             store=store,
         )
-        meta = MODO(path=f"{S3_LOCAL_URL}/{modo}", archive=archive).metadata
+        # TODO: Fix id_ to id once restructure/herarchy is accepted!
+        meta.update(MODO(path=f"{S3_LOCAL_URL}/{modo}", archive=archive).metadata)
 
     return meta

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -55,7 +55,7 @@ def get_s3_path(query: str, exact_match: bool = False):
             modo
             for modo in modos
             if difflib.SequenceMatcher(
-                None, query, modo.replace(BUCKET + "/", "")
+                None, query, modo.removeprefix(BUCKET)
             ).quick_ratio()
             >= 0.7
         ]

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -11,6 +11,11 @@ import os
 
 from fastapi import FastAPI
 from modo.api import MODO
+<<<<<<< HEAD
+=======
+import rdflib
+import re
+>>>>>>> d2468b5 (feat: Add get?query to modo server)
 import s3fs
 import zarr
 
@@ -45,3 +50,19 @@ def gather_metadata():
         meta.update(MODO(path=f"{S3_LOCAL_URL}/{modo}", archive=archive).metadata)
 
     return meta
+
+
+@app.get("/get")
+def get_s3_path(query: str, exact_match: bool = False):
+    """Receive the S3 path of all modos matching the query"""
+    modos = minio.ls(BUCKET)
+    if not exact_match:
+        res = [modo for modo in modos if query in modo]
+    else:
+        # NOTE: Is there a better/more roboust way than regexpr?
+        res = [
+            modo
+            for modo in modos
+            if re.search("/" + query + r"$", modo) is not None
+        ]
+    return [f"{S3_URL}/{modo}" for modo in res]

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -11,7 +11,6 @@ import os
 
 from fastapi import FastAPI
 from modo.api import MODO
-import rdflib
 import re
 import s3fs
 import zarr

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -47,9 +47,7 @@ def get_s3_path(query: str, exact_match: bool = False):
     """Receive the S3 path of all modos matching the query"""
     modos = minio.ls(BUCKET)
     if exact_match:
-        res = [
-            modo for modo in modos if query in modo.removeprefix(BUCKET)
-        ]
+        res = [modo for modo in modos if query in modo.removeprefix(BUCKET)]
     else:
         res = [
             modo

--- a/deploy/modo-server/server.py
+++ b/deploy/modo-server/server.py
@@ -54,7 +54,7 @@ def get_s3_path(query: str, exact_match: bool = False):
     paths = [modo.removeprefix(BUCKET) for modo in modos]
 
     if exact_match:
-        res = [modo for (modo, path) in zip(modos, paths) if query in path]
+        res = [modo for (modo, path) in zip(modos, paths) if query == path]
 
     else:
         sims = [str_similarity(query, path) for path in paths]

--- a/modo/api.py
+++ b/modo/api.py
@@ -19,9 +19,7 @@ from .helpers import (
     copy_file_to_archive,
     dict_to_instance,
     ElementType,
-    is_uri,
     set_haspart_relationship,
-    split_s3_url,
     UserElementType,
 )
 
@@ -50,7 +48,7 @@ class MODO:
     def __init__(
         self,
         path: Union[Path, str],
-        archive: Optional[zarr.Group] = None,
+        s3_endpoint: Optional[str] = None,
         id: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
@@ -59,18 +57,12 @@ class MODO:
         has_assay: List = [],
         source_uri: Optional[str] = None,
     ):
-        if is_uri(path):
-            s3_endpoint, modo_path = split_s3_url(path)
-            archive = zarr.open_group(
-                f"s3://{modo_path}/data.zarr",
+        self.path = Path(path)
+        if s3_endpoint:
+            self.archive = zarr.open_group(
+                f"s3://{path}/data.zarr",
                 storage_options={"anon": True, "endpoint_url": s3_endpoint},
             )
-        else:
-            self.path = Path(path)
-
-        # User provided archive
-        if archive is not None:
-            self.archive = archive
         # Opening existing object
         elif (self.path / "data.zarr").exists():
             self.archive = zarr.open(str(self.path / "data.zarr"))

--- a/modo/helpers.py
+++ b/modo/helpers.py
@@ -186,15 +186,6 @@ def is_uri(text: str):
         return False
 
 
-def split_s3_url(s3_url: str) -> tuple[str, str]:
-    """split s3_url into endpoint_url and file location including bucket name."""
-    parsed_url = urlparse(s3_url)
-    path_parts = parsed_url.path.partition("s3")
-    file_location = path_parts[2].lstrip("/")
-    s3_endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}{path_parts[0]}{path_parts[1]}"
-    return s3_endpoint, file_location
-
-
 def parse_region(region: str) -> tuple[str, int, int]:
     """Parses an input UCSC-format region string into
     (chrom, start, end).

--- a/modo/helpers.py
+++ b/modo/helpers.py
@@ -186,6 +186,15 @@ def is_uri(text: str):
         return False
 
 
+def split_s3_url(s3_url: str) -> tuple[str, str]:
+    """split s3_url into endpoint_url and file location including bucket name."""
+    parsed_url = urlparse(s3_url)
+    path_parts = parsed_url.path.partition("s3")
+    file_location = path_parts[2].lstrip("/")
+    s3_endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}{path_parts[0]}{path_parts[1]}"
+    return s3_endpoint, file_location
+
+
 def parse_region(region: str) -> tuple[str, int, int]:
     """Parses an input UCSC-format region string into
     (chrom, start, end).

--- a/modo/remote.py
+++ b/modo/remote.py
@@ -2,15 +2,15 @@
 
 from pydantic import HttpUrl
 import requests
-from typing import List, Mapping, Optional
+from typing import Mapping, Optional
 
 
-def list_remote_items(remote_url: HttpUrl) -> List[HttpUrl]:
+def list_remote_items(remote_url: HttpUrl) -> list[HttpUrl]:
     return requests.get(url=remote_url + "/list").json()
 
 
 def get_metadata_from_remote(
-    remote_url: HttpUrl, id: Optional[str] = None
+    remote_url: HttpUrl, modo_id: Optional[str] = None
 ) -> Mapping:
     """Function to access metadata from one specific or all modos on a remote server
 
@@ -22,12 +22,12 @@ def get_metadata_from_remote(
         id of the modo to retrieve metadata from. Will return all if not specified (default).
     """
     meta = requests.get(url=remote_url + "/meta").json()
-    if id is not None:
+    if modo_id is not None:
         try:
-            return meta[id]
+            return meta[modo_id]
         except KeyError as e:
             raise ValueError(
-                f"Could not find metadata for modo with id: {id}"
+                f"Could not find metadata for modo with id: {modo_id}"
             ) from e
     else:
         return meta
@@ -35,7 +35,7 @@ def get_metadata_from_remote(
 
 def get_s3_path(
     remote_url: HttpUrl, query: str, exact_match: bool = False
-) -> List:
+) -> list:
     """Request public S3 path of a specific modo or all modos matching the query string
     Parameters
     ----------

--- a/modo/remote.py
+++ b/modo/remote.py
@@ -1,0 +1,52 @@
+"""Functions related to server storage handling"""
+
+from pydantic import HttpUrl
+import requests
+from typing import List, Mapping, Optional
+
+
+def list_remote_items(remote_url: HttpUrl) -> List[HttpUrl]:
+    return requests.get(url=remote_url + "/list").json()
+
+
+def get_metadata_from_remote(
+    remote_url: HttpUrl, id: Optional[str] = None
+) -> Mapping:
+    """Function to access metadata from one specific or all modos on a remote server
+
+    Parameters
+    ----------
+    server_url
+        Url to the remote modo server
+    id
+        id of the modo to retrieve metadata from. Will return all if not specified (default).
+    """
+    meta = requests.get(url=remote_url + "/meta").json()
+    if id is not None:
+        try:
+            return meta[id]
+        except KeyError as e:
+            raise ValueError(
+                f"Could not find metadata for modo with id: {id}"
+            ) from e
+    else:
+        return meta
+
+
+def get_s3_path(
+    remote_url: HttpUrl, query: str, exact_match: bool = False
+) -> List:
+    """Request public S3 path of a specific modo or all modos matching the query string
+    Parameters
+    ----------
+    remote_url
+        Url to the remote modo server
+    query
+        query string to specify the modo of interest
+    exact_match
+        if True only modos with exactly that id will be returned, otherwise (default) all matching modos
+    """
+    return requests.get(
+        url=remote_url + "/get",
+        params={"query": query, "exact_match": exact_match},
+    ).json()

--- a/modo/storage.py
+++ b/modo/storage.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from pydantic import HttpUrl
 import requests
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional
 
 from linkml_runtime.loaders import json_loader
 import zarr
@@ -56,8 +56,34 @@ def list_zarr_items(group: zarr.Group) -> list[zarr.Group | zarr.Array]:
 
 
 def list_server_items(server_url: HttpUrl) -> List[HttpUrl]:
-    requests.get(url=server_url + "/list").json()
+    return requests.get(url=server_url + "/list").json()
 
 
-def get_metadata_from_server(server_url: HttpUrl, id: Optional[str] = None):
-    requests.get(url=server_url + "/meta").json()
+def get_metadata_from_server(
+    server_url: HttpUrl, id: Optional[str] = None
+) -> Mapping:
+    """Function to access metadata from one specific or all modos on a remote server
+
+    Parameters
+    ----------
+    server_url
+        Url to the remote modo server
+    id
+        id of the modo to retrieve metadata from. Will return all if not specified (default).S
+    """
+    meta = requests.get(url=server_url + "/meta").json()
+    if id is not None:
+        try:
+            return meta[id]
+        except KeyError as e:
+            raise ValueError(
+                f"Could not find metadata for modo with id: {id}"
+            ) from e
+    else:
+        return meta
+
+
+def get_s3(server_url: HttpUrl, query: str, exact_match: bool = False):
+    return requests.get(
+        url=f"server_url + /get?query={query}&exact_match={exact_match}"
+    ).json()

--- a/modo/storage.py
+++ b/modo/storage.py
@@ -1,13 +1,8 @@
-import json
 from pathlib import Path
-from pydantic import HttpUrl
-import requests
-from typing import Any, List, Mapping, Optional
-
-from linkml_runtime.loaders import json_loader
 import zarr
 
-from .helpers import ElementType, UserElementType
+
+from .helpers import ElementType
 
 
 # Initialize object's directory given the metadata graph
@@ -50,40 +45,3 @@ def list_zarr_items(group: zarr.Group) -> list[zarr.Group | zarr.Array]:
 
     group.visititems(list_all)
     return found
-
-
-## Functions related to server storage handling
-
-
-def list_server_items(server_url: HttpUrl) -> List[HttpUrl]:
-    return requests.get(url=server_url + "/list").json()
-
-
-def get_metadata_from_server(
-    server_url: HttpUrl, id: Optional[str] = None
-) -> Mapping:
-    """Function to access metadata from one specific or all modos on a remote server
-
-    Parameters
-    ----------
-    server_url
-        Url to the remote modo server
-    id
-        id of the modo to retrieve metadata from. Will return all if not specified (default).S
-    """
-    meta = requests.get(url=server_url + "/meta").json()
-    if id is not None:
-        try:
-            return meta[id]
-        except KeyError as e:
-            raise ValueError(
-                f"Could not find metadata for modo with id: {id}"
-            ) from e
-    else:
-        return meta
-
-
-def get_s3(server_url: HttpUrl, query: str, exact_match: bool = False) -> List:
-    return requests.get(
-        url=server_url + f"/get?query={query}&exact_match={exact_match}"
-    ).json()

--- a/modo/storage.py
+++ b/modo/storage.py
@@ -83,7 +83,7 @@ def get_metadata_from_server(
         return meta
 
 
-def get_s3(server_url: HttpUrl, query: str, exact_match: bool = False):
+def get_s3(server_url: HttpUrl, query: str, exact_match: bool = False) -> List:
     return requests.get(
-        url=f"server_url + /get?query={query}&exact_match={exact_match}"
+        url=server_url + f"/get?query={query}&exact_match={exact_match}"
     ).json()

--- a/modo/storage.py
+++ b/modo/storage.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
-from typing import Any
+from pydantic import HttpUrl
+import requests
+from typing import Any, List, Optional
 
 from linkml_runtime.loaders import json_loader
 import zarr
@@ -48,3 +50,14 @@ def list_zarr_items(group: zarr.Group) -> list[zarr.Group | zarr.Array]:
 
     group.visititems(list_all)
     return found
+
+
+## Functions related to server storage handling
+
+
+def list_server_items(server_url: HttpUrl) -> List[HttpUrl]:
+    requests.get(url=server_url + "/list").json()
+
+
+def get_metadata_from_server(server_url: HttpUrl, id: Optional[str] = None):
+    requests.get(url=server_url + "/meta").json()


### PR DESCRIPTION
Related to https://github.com/sdsc-ordes/modo-api/issues/15:
__Main goal:__
Add capabilities to locally instantiate remote modo(s).

__Includes__:
- `modo.api.MODO()` accepts and handles remote s3 paths
- modo.remote includes new functions `list_remote_items()`, `get_metadata_from_remote()`  and `get_s3_path()` to directly access modo.server endpoints
- new modo.server endpoint to get the public s3 path of all modos match a query

__Open question__:
1. I'm happy to add matching cli functions e.g. `modo list REMOTE_URL` etc.. Would that be useful?
2. `modo.helpers.split_s3_url()` works with simple and unstable string manipulation. I would prefer something more robust! If we want to keep the current setup with one remote path we need to somehow split it into `s3 endpoint url` and `bucket path + modo_path`to align with the syntax of `zarr.open_gorup()`. I couldn't find a good alternative to this. We could do something like: 
```py
class MODO:
    def __init__(
        self,
        path: Union[Path, str],
        s3_endpoint: Optional[str]
    ):
        if s3_endpoint:
            archive=...
``` 
This would require the user to specify the s3_endpoint in addition, though.
Any preferences or ideas to better solve this issue? 