### PR TITLE
ci: docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,16 +1,16 @@
 name: Publish on Github container registry
 
 on:
+  workflow_dispatch:
   release:
     type: [published]
   push:
     branches:
       - main
-      - feat/ci_docker_build
   pull_request:
-    paths:
-      - 'pyproject.toml'
-      - 'Dockerfile'
+    types:
+      - opened
+      - reopened
 
 env:
   REGISTRY: ghcr.io
@@ -52,7 +52,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' || github.event_name == 'pull_request'}}
             type=raw,value=${{ steps.release-version.outputs.version }},enable=${{ github.event_name == 'release' }}
 
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,62 @@
+name: Publish on Github container registry
+
+on:
+  release:
+    type: [published]
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'Dockerfile'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: lowercase image name
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+
+      - name: Get current release version
+        id: release-version
+        run: |
+          version=$(grep -E '^version += +' pyproject.toml | sed -E 's/.*= +//' | sed "s/['\"]//g")
+          echo "version=${version}" >> $GITHUB_OUTPUT
+
+      # https://github.com/docker/login-action
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # https://github.com/docker/metadata-action
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+            type=raw,value=${{ steps.release-version.outputs.version }},enable=${{ github.event_name == 'release' }}
+
+      # https://github.com/docker/build-push-action
+      - name: Push Docker image
+        uses: docker/build-push-action@v5.0.0
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          outputs: type=image,annotation-index.org.opencontainers.image.description=Serve multi-omics digital objects.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,9 @@ on:
   release:
     type: [published]
   push:
-    branches: [main]
+    branches:
+      - main
+      - feat/ci_docker_build
   pull_request:
     paths:
       - 'pyproject.toml'


### PR DESCRIPTION
## Ci workflow: docker-publish
Include a ci workflow to automatically build the __client docker__ image and push it to ghcr.
This workflow should:
1. always add `latest` tag.
2. add modo-api version as tag upon releases
3. run on push to main, releases and changes in `Dockerfile` or `pyproject.yaml` in PRs

__Ops__: For testing it will currently also run on push to this branch (`feat/ci_docker_build`). 
The output of the last run can be found at https://github.com/sdsc-ordes/modo-api/actions/runs/8245306630 
`feat/ci_docker_build` should be removed before merge:
```sh
    push:
       branches:
         - main
         - feat/ci_docker_build
```

