### PR TITLE
fix(deploy): disable body size limit in nginx

### DIFF
--- a/deploy/nginx/default.conf.template
+++ b/deploy/nginx/default.conf.template
@@ -2,6 +2,7 @@
 
 server {
   listen 80 ;
+  client_max_body_size 0 ;
 
   # Inform client about public URLs
   location = / {


### PR DESCRIPTION
The [`client_max_body_size`](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) in nginx is set to 1MB by default. This prevents uploading genomic files, which are normally several orders of magnitude larger.

This PR disables ths limit.

Successfully uploaded a 50GB CRAM file on a test deployment with this fix.