### PR TITLE
fix(server): pin htsget version + bump msrv

### DIFF
--- a/deploy/htsget/Dockerfile
+++ b/deploy/htsget/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.74.0 AS builder
+FROM rust:1.75.0 AS builder
 
 WORKDIR /build
 

--- a/deploy/htsget/Dockerfile
+++ b/deploy/htsget/Dockerfile
@@ -6,7 +6,7 @@ RUN cargo install cargo-strip
 
 RUN apt-get update && apt-get install -y git
 
-RUN git clone https://github.com/umccr/htsget-rs.git .
+RUN git clone https://github.com/umccr/htsget-rs.git --branch htsget-actix-v0.6.1 .
 
 
 RUN cargo build --features s3-storage --release && cargo strip


### PR DESCRIPTION
htsget minimum supported rust version (msrv) is now 1.75, but our htsget service used 1.74 as the base layer.

This PR pins htsget to the latest release and bumps the MSRV in our base layer.